### PR TITLE
Drop non-informative inline documentation

### DIFF
--- a/EasyRdf/Graph.php
+++ b/EasyRdf/Graph.php
@@ -62,10 +62,7 @@ class EasyRdf_Graph
 
     private $maxRedirects = 10;
 
-
     /**
-     * Constructor
-     *
      * If no URI is given then an unnamed graph is created.
      *
      * The $data parameter is optional and will be parsed into
@@ -77,7 +74,6 @@ class EasyRdf_Graph
      * @param  string  $uri     The URI of the graph
      * @param  string  $data    Data for the graph
      * @param  string  $format  The document type of the data (e.g. rdfxml)
-     * @return object EasyRdf_Graph
      */
     public function __construct($uri = null, $data = null, $format = null)
     {

--- a/EasyRdf/Literal.php
+++ b/EasyRdf/Literal.php
@@ -188,14 +188,11 @@ class EasyRdf_Literal
         }
     }
 
-
-
     /** Constructor for creating a new literal
      *
      * @param  string $value     The value of the literal
      * @param  string $lang      The natural language of the literal or null (e.g. 'en')
      * @param  string $datatype  The datatype of the literal or null (e.g. 'xsd:string')
-     * @return object EasyRdf_Literal
      */
     public function __construct($value, $lang = null, $datatype = null)
     {

--- a/EasyRdf/Literal/Boolean.php
+++ b/EasyRdf/Literal/Boolean.php
@@ -52,7 +52,6 @@ class EasyRdf_Literal_Boolean extends EasyRdf_Literal
      * @param  mixed  $value     The value of the literal
      * @param  string $lang      Should be null (literals with a datatype can't have a language)
      * @param  string $datatype  Optional datatype (default 'xsd:boolean')
-     * @return object EasyRdf_Literal_Boolean
      */
     public function __construct($value, $lang = null, $datatype = null)
     {

--- a/EasyRdf/Literal/Date.php
+++ b/EasyRdf/Literal/Date.php
@@ -55,7 +55,6 @@ class EasyRdf_Literal_Date extends EasyRdf_Literal
      * @param  mixed  $value     The value of the literal
      * @param  string $lang      Should be null (literals with a datatype can't have a language)
      * @param  string $datatype  Optional datatype (default 'xsd:date')
-     * @return object EasyRdf_Literal_Date
      */
     public function __construct($value = null, $lang = null, $datatype = null)
     {

--- a/EasyRdf/Literal/DateTime.php
+++ b/EasyRdf/Literal/DateTime.php
@@ -55,7 +55,6 @@ class EasyRdf_Literal_DateTime extends EasyRdf_Literal_Date
      * @param  mixed  $value     The value of the literal
      * @param  string $lang      Should be null (literals with a datatype can't have a language)
      * @param  string $datatype  Optional datatype (default 'xsd:dateTime')
-     * @return object EasyRdf_Literal_DateTime
      */
     public function __construct($value = null, $lang = null, $datatype = null)
     {

--- a/EasyRdf/Literal/Decimal.php
+++ b/EasyRdf/Literal/Decimal.php
@@ -50,7 +50,6 @@ class EasyRdf_Literal_Decimal extends EasyRdf_Literal
      * @param  mixed  $value     The value of the literal
      * @param  string $lang      Should be null (literals with a datatype can't have a language)
      * @param  string $datatype  Optional datatype (default 'xsd:decimal')
-     * @return object EasyRdf_Literal_Decimal
      */
     public function __construct($value, $lang = null, $datatype = null)
     {

--- a/EasyRdf/Literal/HexBinary.php
+++ b/EasyRdf/Literal/HexBinary.php
@@ -50,7 +50,6 @@ class EasyRdf_Literal_HexBinary extends EasyRdf_Literal
      * @param  mixed  $value     The value of the literal (already encoded as hexadecimal)
      * @param  string $lang      Should be null (literals with a datatype can't have a language)
      * @param  string $datatype  Optional datatype (default 'xsd:hexBinary')
-     * @return object EasyRdf_Literal_HexBinary
      */
     public function __construct($value, $lang = null, $datatype = null)
     {

--- a/EasyRdf/Literal/Integer.php
+++ b/EasyRdf/Literal/Integer.php
@@ -50,7 +50,6 @@ class EasyRdf_Literal_Integer extends EasyRdf_Literal
      * @param  mixed  $value     The value of the literal
      * @param  string $lang      Should be null (literals with a datatype can't have a language)
      * @param  string $datatype  Optional datatype (default 'xsd:integer')
-     * @return object EasyRdf_Literal_Integer
      */
     public function __construct($value, $lang = null, $datatype = null)
     {

--- a/EasyRdf/Serialiser/Arc.php
+++ b/EasyRdf/Serialiser/Arc.php
@@ -51,11 +51,6 @@ class EasyRdf_Serialiser_Arc extends EasyRdf_Serialiser_RdfPhp
         'posh' => 'POSHRDF'
     );
 
-    /**
-     * Constructor
-     *
-     * @return object EasyRdf_Serialiser_Arc
-     */
     public function __construct()
     {
         require_once 'arc/ARC2.php';

--- a/EasyRdf/Serialiser/GraphViz.php
+++ b/EasyRdf/Serialiser/GraphViz.php
@@ -53,11 +53,6 @@ class EasyRdf_Serialiser_GraphViz extends EasyRdf_Serialiser
     private $onlyLabelled = false;
     private $attributes = array('charset' => 'utf-8');
 
-    /**
-     * Constructor
-     *
-     * @return object EasyRdf_Serialiser_GraphViz
-     */
     public function __construct()
     {
     }

--- a/EasyRdf/Serialiser/Rapper.php
+++ b/EasyRdf/Serialiser/Rapper.php
@@ -50,10 +50,7 @@ class EasyRdf_Serialiser_Rapper extends EasyRdf_Serialiser_Ntriples
     private $rapperCmd = null;
 
     /**
-     * Constructor
-     *
      * @param string $rapperCmd Optional path to the rapper command to use.
-     * @return object EasyRdf_Serialiser_Rapper
      */
     public function __construct($rapperCmd = 'rapper')
     {


### PR DESCRIPTION
This mistake was mentioned in https://github.com/DataValues/Interfaces/pull/5. I did a regex search and found very few occurrences, most of them in this module.
