### PR TITLE
Add namespace EasyRdf and psr-4 autoloader

### DIFF
--- a/EasyRdf/Exception.php
+++ b/EasyRdf/Exception.php
@@ -35,6 +35,10 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
+use Exception;
+
 /**
  * EasyRdf Exception class
  *

--- a/EasyRdf/Format.php
+++ b/EasyRdf/Format.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class the represents an RDF file format.
  *

--- a/EasyRdf/Graph.php
+++ b/EasyRdf/Graph.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Container for collection of EasyRdf_Resources.
  *

--- a/EasyRdf/Literal.php
+++ b/EasyRdf/Literal.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class that represents an RDF Literal
  *

--- a/EasyRdf/Literal/Boolean.php
+++ b/EasyRdf/Literal/Boolean.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class that represents an RDF Literal of datatype xsd:boolean
  *

--- a/EasyRdf/Literal/Date.php
+++ b/EasyRdf/Literal/Date.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class that represents an RDF Literal of datatype xsd:date
  *

--- a/EasyRdf/Literal/DateTime.php
+++ b/EasyRdf/Literal/DateTime.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class that represents an RDF Literal of datatype xsd:dateTime
  *

--- a/EasyRdf/Literal/Decimal.php
+++ b/EasyRdf/Literal/Decimal.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class that represents an RDF Literal of datatype xsd:decimal
  *

--- a/EasyRdf/Literal/HexBinary.php
+++ b/EasyRdf/Literal/HexBinary.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class that represents an RDF Literal of datatype xsd:hexBinary
  *

--- a/EasyRdf/Literal/Integer.php
+++ b/EasyRdf/Literal/Integer.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class that represents an RDF Literal of datatype xsd:integer
  *

--- a/EasyRdf/Namespace.php
+++ b/EasyRdf/Namespace.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * A namespace registry and manipulation class.
  *
@@ -333,7 +335,7 @@ class EasyRdf_Namespace
                 "\$shortUri should be a string and cannot be null or empty"
             );
         }
-        
+
         if ($shortUri === 'a') {
             return self::$namespaces['rdf'] . 'type';
         } elseif (preg_match("/^(\w+?):([\w\-]+)$/", $shortUri, $matches)) {

--- a/EasyRdf/Resource.php
+++ b/EasyRdf/Resource.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class that represents an RDF resource
  *

--- a/EasyRdf/Serialiser.php
+++ b/EasyRdf/Serialiser.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Parent class for the EasyRdf serialiser
  *

--- a/EasyRdf/Serialiser/Arc.php
+++ b/EasyRdf/Serialiser/Arc.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class to serialise RDF using the ARC2 library.
  *

--- a/EasyRdf/Serialiser/GraphViz.php
+++ b/EasyRdf/Serialiser/GraphViz.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class to serialise an EasyRdf_Graph to GraphViz
  *
@@ -215,7 +217,7 @@ class EasyRdf_Serialiser_GraphViz extends EasyRdf_Serialiser
      */
     protected function escapeAttributes($array)
     {
-        $items = '';
+        $items = [];
         foreach ($array as $k => $v) {
             $items[] = $this->escape($k).'='.$this->escape($v);
         }

--- a/EasyRdf/Serialiser/Json.php
+++ b/EasyRdf/Serialiser/Json.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class to serialise an EasyRdf_Graph to RDF/JSON
  * with no external dependancies.

--- a/EasyRdf/Serialiser/Ntriples.php
+++ b/EasyRdf/Serialiser/Ntriples.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class to serialise an EasyRdf_Graph to N-Triples
  * with no external dependancies.

--- a/EasyRdf/Serialiser/Rapper.php
+++ b/EasyRdf/Serialiser/Rapper.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class to serialise an EasyRdf_Graph to RDF
  * using the 'rapper' command line tool.

--- a/EasyRdf/Serialiser/RdfPhp.php
+++ b/EasyRdf/Serialiser/RdfPhp.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class to serialise an EasyRdf_Graph to RDF/PHP
  * with no external dependancies.

--- a/EasyRdf/Serialiser/RdfXml.php
+++ b/EasyRdf/Serialiser/RdfXml.php
@@ -34,6 +34,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class to serialise an EasyRdf_Graph to RDF/XML
  * with no external dependancies.

--- a/EasyRdf/Serialiser/Turtle.php
+++ b/EasyRdf/Serialiser/Turtle.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class to serialise an EasyRdf_Graph to Turtle
  * with no external dependancies.

--- a/EasyRdf/TypeMapper.php
+++ b/EasyRdf/TypeMapper.php
@@ -35,6 +35,8 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
+
 /**
  * Class to map between RDF Types and PHP Classes
  *

--- a/EasyRdf/Utils.php
+++ b/EasyRdf/Utils.php
@@ -35,6 +35,7 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
+namespace EasyRdf;
 
 /**
  * Class containing static utility functions

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-		"name": "wikibase/easyrdf_lite",
-		"description": "EasyRdf Lite is a customized version of EasyRdf",
-		"homepage": "https://github.com/Wikidata/easyrdf_lite",
-		"license": "BSD",
-		"autoload": {
-			"psr-0": {
-				"EasyRdf_": "./"
-			}
+	"name": "wikibase/easyrdf_lite",
+	"description": "EasyRdf Lite is a customized version of EasyRdf",
+	"homepage": "https://github.com/Wikidata/easyrdf_lite",
+	"license": "BSD",
+	"autoload": {
+		"psr-4": {
+			"EasyRdf\\": "EasyRdf/"
 		}
+	}
 }


### PR DESCRIPTION
# Changed log
- Add `EasyRdf` namespace for all classes.
- The `psr-0` autoloader is deprecated. Using the `psr-4` autoloader instead.